### PR TITLE
Add centerline yaw and align start position

### DIFF
--- a/src/tracks/base_track.rs
+++ b/src/tracks/base_track.rs
@@ -36,6 +36,12 @@ pub trait Track {
     /// # Returns
     /// Reference to the list of (x, y) coordinates defining the center line
     fn get_center_line(&self) -> &[(f64, f64)];
+
+    /// Get the yaw orientation along the center line
+    ///
+    /// # Returns
+    /// Reference to the list of yaw angles (radians) corresponding to each center line point
+    fn get_center_line_yaw(&self) -> &[f64];
     
     /// Get the inside boundary coordinates
     /// 
@@ -60,4 +66,25 @@ pub trait Track {
     /// # Returns
     /// Tuple of (min_coord, max_coord) for the plot range
     fn get_plot_range(&self) -> (f64, f64);
+}
+
+/// Compute yaw angles for a closed center line using forward differences.
+pub fn compute_center_line_yaw(center_line: &[(f64, f64)]) -> Vec<f64> {
+    let n = center_line.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    if n == 1 {
+        return vec![0.0];
+    }
+
+    let mut yaw = Vec::with_capacity(n);
+    for i in 0..n {
+        let (x0, y0) = center_line[i];
+        let (x1, y1) = center_line[(i + 1) % n];
+        let dx = x1 - x0;
+        let dy = y1 - y0;
+        yaw.push(dy.atan2(dx));
+    }
+    yaw
 }

--- a/tests/test_circle_track.rs
+++ b/tests/test_circle_track.rs
@@ -15,10 +15,11 @@ fn test_circle_track_creation() {
 fn test_circle_track_get_start_position() {
     let track = CircleTrack::new(50.0, 10.0, 100);
     let start = track.get_start_position();
+    let yaw = track.get_center_line_yaw()[0];
     
     assert!((start.0 - 50.0).abs() < 1e-10);
     assert!((start.1 - 0.0).abs() < 1e-10);
-    assert!((start.2 - PI / 2.0).abs() < 1e-10);
+    assert!((start.2 - yaw).abs() < 1e-10);
 }
 
 #[test]
@@ -29,6 +30,18 @@ fn test_circle_track_center_line_first_point() {
     let first_point = center_line[0];
     assert!((first_point.0 - 50.0).abs() < 1e-10);
     assert!((first_point.1 - 0.0).abs() < 1e-10);
+}
+
+#[test]
+fn test_circle_track_center_line_yaw() {
+    let track = CircleTrack::new(50.0, 10.0, 360);
+    let center_line = track.get_center_line();
+    let yaw = track.get_center_line_yaw();
+
+    assert_eq!(yaw.len(), center_line.len());
+
+    // At angle 0, tangent should point upward (~pi/2)
+    assert!((yaw[0] - PI / 2.0).abs() < 0.1);
 }
 
 #[test]
@@ -110,11 +123,13 @@ fn test_circle_track_with_different_sizes() {
     
     let start1 = track1.get_start_position();
     let start2 = track2.get_start_position();
+    let yaw1 = track1.get_center_line_yaw()[0];
+    let yaw2 = track2.get_center_line_yaw()[0];
     
     assert!((start1.0 - 30.0).abs() < 1e-10);
     assert!((start2.0 - 100.0).abs() < 1e-10);
-    assert!((start1.2 - PI / 2.0).abs() < 1e-10);
-    assert!((start2.2 - PI / 2.0).abs() < 1e-10);
+    assert!((start1.2 - yaw1).abs() < 1e-10);
+    assert!((start2.2 - yaw2).abs() < 1e-10);
 }
 
 #[test]

--- a/tests/test_square_track.rs
+++ b/tests/test_square_track.rs
@@ -15,11 +15,12 @@ fn test_square_track_creation() {
 fn test_square_track_get_start_position() {
     let track = SquareTrack::new(100.0, 10.0, 25);
     let start = track.get_start_position();
+    let yaw = track.get_center_line_yaw()[0];
     
-    // Start position should be at (height/2, 0, 0) = (50, 0, 0)
+    // Start position should be at first center line point with matching yaw
     assert!((start.0 - 50.0).abs() < 1e-10);
-    assert!((start.1 - 0.0).abs() < 1e-10);
-    assert!((start.2 - 0.0).abs() < 1e-10);
+    assert!((start.1 - (-50.0)).abs() < 1e-10);
+    assert!((start.2 - yaw).abs() < 1e-10);
 }
 
 #[test]
@@ -31,6 +32,25 @@ fn test_square_track_center_line_first_point() {
     let first_point = center_line[0];
     assert!((first_point.0 - 50.0).abs() < 1e-10);
     assert!((first_point.1 - (-50.0)).abs() < 1e-10);
+}
+
+#[test]
+fn test_square_track_center_line_yaw() {
+    let points_per_side = 25;
+    let track = SquareTrack::new(100.0, 10.0, points_per_side);
+    let center_line = track.get_center_line();
+    let yaw = track.get_center_line_yaw();
+
+    assert_eq!(yaw.len(), center_line.len());
+
+    // Right side (moving up)
+    assert!((yaw[0] - std::f64::consts::FRAC_PI_2).abs() < 1e-10);
+    // Top side (moving left)
+    assert!((yaw[points_per_side] - std::f64::consts::PI).abs() < 1e-10);
+    // Left side (moving down)
+    assert!((yaw[2 * points_per_side] + std::f64::consts::FRAC_PI_2).abs() < 1e-10);
+    // Bottom side (moving right)
+    assert!(yaw[3 * points_per_side].abs() < 1e-10);
 }
 
 #[test]
@@ -115,12 +135,16 @@ fn test_square_track_with_different_sizes() {
     
     let start1 = track1.get_start_position();
     let start2 = track2.get_start_position();
+    let yaw1 = track1.get_center_line_yaw()[0];
+    let yaw2 = track2.get_center_line_yaw()[0];
     
-    // start should be (height/2, 0, 0)
+    // start should match first center line point and yaw
     assert!((start1.0 - 40.0).abs() < 1e-10);
+    assert!((start1.1 - (-40.0)).abs() < 1e-10);
     assert!((start2.0 - 100.0).abs() < 1e-10);
-    assert!((start1.2 - 0.0).abs() < 1e-10);
-    assert!((start2.2 - 0.0).abs() < 1e-10);
+    assert!((start2.1 - (-100.0)).abs() < 1e-10);
+    assert!((start1.2 - yaw1).abs() < 1e-10);
+    assert!((start2.2 - yaw2).abs() < 1e-10);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add centerline yaw accessors to tracks
- compute and store centerline yaw for circle and square tracks
- align track start position to first centerline point/yaw
- update tests for new start position behavior

## Testing
- cargo test
- cargo run
