### PR TITLE
Add CLI help tip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Run the simulation:
 cargo run --bin lap_simulation
 ```
 
+Tip: Use `cargo run --bin lap_simulation -- --help` to see available CLI options.
+
 Run tests:
 ```bash
 cargo test


### PR DESCRIPTION
### Motivation

- Make it easier to discover available CLI options for the `lap_simulation` binary by documenting how to call its help.

### Description

- Add a short tip to `README.md` showing `cargo run --bin lap_simulation -- --help`.

### Testing

- Ran `cargo test` which completed successfully (`52 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9a66c574832e8cfc9fe631d842ba)