### PR TITLE
Add open-loop CI workflow and enable nonzero lateral acceleration

### DIFF
--- a/.github/workflows/open-loop-artifacts.yml
+++ b/.github/workflows/open-loop-artifacts.yml
@@ -1,0 +1,28 @@
+name: Open Loop Artifacts
+
+on:
+  pull_request:
+    branches: ["master"]
+    types: [opened, synchronize, reopened]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  open-loop:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/sebibi/lap_simulation-ci:ffmpeg
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run open-loop simulation
+        run: cargo run --bin lap_simulation
+      - name: Upload open-loop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: open-loop-results
+          path: |
+            results/images/initial_state.svg
+            results/images/final_state.svg
+            results/images/open_loop.mp4

--- a/src/simulation/open_loop.rs
+++ b/src/simulation/open_loop.rs
@@ -27,8 +27,8 @@ pub fn open_loop(output_dir: &str, dt: f64, duration: f64) {
     model.set_position(start_pos.0, start_pos.1, start_pos.2);
     println!("Model starting position: ({:.3}, {:.3}, {:.3})\n", start_pos.0, start_pos.1, start_pos.2);
     
-    // Set constant acceleration inputs (e.g., 2 m/s^2 in x, 0 m/s^2 in y)
-    model.set_controls(2.0, 0.0);
+    // Set constant acceleration inputs (e.g., 2 m/s^2 in x, 1 m/s^2 in y)
+    model.set_controls(2.0, 1.0);
 
     let fps = 10u32;
     let frame_times = scheduled_frame_times(duration, fps);


### PR DESCRIPTION
### Motivation
- Add a CI workflow that runs the open-loop demo and uploads generated visuals so reviewers can inspect `initial_state.svg`, `final_state.svg`, and `open_loop.mp4` without checking generated files into the repo. 
- Ensure the open-loop demo reflects a nonzero body-frame lateral acceleration so visuals show lateral motion instead of being purely longitudinal.

### Description
- Add `.github/workflows/open-loop-artifacts.yml` which runs the open-loop binary in the `ghcr.io/sebibi/lap_simulation-ci:ffmpeg` container and uploads results as a PR artifact named `open-loop-results` at paths `results/images/initial_state.svg`, `results/images/final_state.svg`, and `results/images/open_loop.mp4`.
- Run the binary in CI with the command `cargo run --bin lap_simulation` as part of the workflow steps.
- Update `src/simulation/open_loop.rs` to call `model.set_controls(2.0, 1.0)` so the demo applies `1.0` m/s^2 lateral acceleration in the body frame instead of `0.0`.

### Testing
- No automated unit or integration tests were executed as part of this change (workflow-only), so `cargo test` was not run in this PR and no test failures were reported. 
- The new workflow is configured to run on pull requests (`on: pull_request`) and will produce and upload the SVG/MP4 artifacts when a PR is opened or updated, but it has not yet been executed in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9e7457ac832e9654077b1af54f7c)