### PR TITLE
Make open-loop workflow reusable

### DIFF
--- a/.github/workflows/open-loop-artifacts.yml
+++ b/.github/workflows/open-loop-artifacts.yml
@@ -1,9 +1,7 @@
 name: Open Loop Artifacts
 
 on:
-  pull_request:
-    branches: ["master"]
-    types: [opened, synchronize, reopened]
+  workflow_call:
   workflow_dispatch:
 
 env:
@@ -28,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/sebibi/lap_simulation-ci:ffmpeg
+    env:
+      PREVIEW_ID: ${{ github.event.pull_request.number || 'manual' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         run: cargo run --bin lap_simulation
       - name: Prepare GitHub Pages preview
         run: |
-          preview_dir="results/pages/previews/pr-${{ github.event.pull_request.number }}"
+          preview_dir="results/pages/previews/pr-${{ env.PREVIEW_ID }}"
           mkdir -p "$preview_dir"
           cp results/images/open_loop_preview.html "$preview_dir/index.html"
           cp results/images/open_loop.mp4 "$preview_dir/"
@@ -50,7 +50,7 @@ jobs:
         uses: actions/deploy-pages@v4
       - name: Add preview link to workflow summary
         run: |
-          preview_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/"
+          preview_url="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ env.PREVIEW_ID }}/"
           {
             echo "## Open-loop preview"
             echo ""
@@ -62,7 +62,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Open-loop preview: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ github.event.pull_request.number }}/
+            Open-loop preview: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/previews/pr-${{ env.PREVIEW_ID }}/
       - name: Upload open-loop artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,3 +23,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  open-loop:
+    needs: build
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/open-loop-artifacts.yml


### PR DESCRIPTION
## Summary
This PR converts the open-loop artifacts workflow into a reusable workflow and wires it into the Rust CI as a second job so it only runs after tests pass.

## Changes
- `.github/workflows/open-loop-artifacts.yml`: switch to `workflow_call`, add a fallback preview ID for non-PR runs, and keep Pages/artifact steps intact.
- `.github/workflows/rust.yml`: add an `open-loop` job that depends on the build/test job and calls the reusable workflow with its required permissions.

## Why
Running the open-loop artifacts job only after a successful Rust test run keeps the CI signal clear while still generating previews for PRs.

## Testing
- not run (workflow change only)