### PR TITLE
Include initial/final frames in open-loop preview HTML

### DIFF
--- a/tests/simulation/open_loop.rs
+++ b/tests/simulation/open_loop.rs
@@ -1,4 +1,5 @@
 use lap_simulation::simulation::open_loop::open_loop;
+use std::fs;
 use std::process::Command;
 
 #[test]
@@ -22,8 +23,37 @@ fn test_open_loop_simulation_outputs_svgs_and_video() {
     let initial_svg = output_path.join("initial_state.svg");
     let final_svg = output_path.join("final_state.svg");
     let video_mp4 = output_path.join("open_loop.mp4");
+    let preview_html = output_path.join("open_loop_preview.html");
 
     assert!(initial_svg.exists(), "missing initial_state.svg in output dir");
     assert!(final_svg.exists(), "missing final_state.svg in output dir");
     assert!(video_mp4.exists(), "missing open_loop.mp4 in output dir");
+    assert!(preview_html.exists(), "missing open_loop_preview.html in output dir");
+
+    let preview_contents = fs::read_to_string(&preview_html)
+        .expect("failed to read open_loop_preview.html");
+    assert!(
+        preview_contents.contains("open_loop.mp4"),
+        "preview html should reference open_loop.mp4"
+    );
+    assert!(
+        preview_contents.contains("initial_state.svg"),
+        "preview html should reference initial_state.svg"
+    );
+    assert!(
+        preview_contents.contains("final_state.svg"),
+        "preview html should reference final_state.svg"
+    );
+
+    let leftover_step_svgs: Vec<_> = fs::read_dir(&output_path)
+        .expect("failed to read output dir")
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.file_name().into_string().ok())
+        .filter(|name| name.starts_with("step_") && name.ends_with(".svg"))
+        .collect();
+    assert!(
+        leftover_step_svgs.is_empty(),
+        "expected step SVGs to be cleaned up, found: {:?}",
+        leftover_step_svgs
+    );
 }


### PR DESCRIPTION
### Motivation
- The open-loop preview previously received initial/final frame paths but did not render them, leaving the preview incomplete and making regressions undetected.
- Normalize absolute/relative media paths before emitting HTML so embedded image references are valid when files exist.

### Description
- Render initial and final frame images in `write_open_loop_html_preview` when the corresponding files exist and wrap them in a `.media` section with captions.
- Add a `normalize_media_path` helper to resolve and validate absolute or output-relative paths before emitting references in the HTML.
- Expand the unit test for `write_open_loop_html_preview` in `src/plotting/conversion.rs` to write sample `initial_state.svg` and `final_state.svg` and assert the HTML contains their filenames.
- Extend the integration test `tests/simulation/open_loop.rs` to assert `open_loop_preview.html` exists, contains `open_loop.mp4`, `initial_state.svg`, and `final_state.svg`, and to verify intermediate `step_*.svg` files are cleaned up.

### Testing
- Ran `cargo test --verbose --features ffmpeg test_write_open_loop_html_preview`, which completed successfully (`ok`).
- Ran `cargo test --verbose --features ffmpeg test_open_loop_simulation_outputs_svgs_and_video`, which executed the integration test with `ffmpeg` and passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fce9923b0832ea9716ed8d53102d4)