### PR TITLE
Add controllers module with Stanley and Pure Pursuit implementations

### DIFF
--- a/src/controllers/base_controller.rs
+++ b/src/controllers/base_controller.rs
@@ -1,0 +1,77 @@
+use crate::models::base_model::Model;
+use crate::tracks::base_track::Track;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ControlInput {
+    pub ax: f64,
+    pub yaw_rate: f64,
+}
+
+impl ControlInput {
+    pub fn new(ax: f64, yaw_rate: f64) -> Self {
+        Self { ax, yaw_rate }
+    }
+}
+
+impl fmt::Display for ControlInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ControlInput {{ ax: {:.3} m/s², yaw_rate: {:.3} rad/s }}",
+            self.ax, self.yaw_rate
+        )
+    }
+}
+
+/// Trait for controller implementations with standard lifecycle methods.
+pub trait Controller {
+    type Model: Model;
+    type Track: Track;
+    type Parameters: fmt::Display + Clone;
+
+    /// Initialize the controller with the current model, track, and parameters.
+    fn init(&mut self, model: &Self::Model, track: Self::Track, parameters: Self::Parameters);
+
+    /// Compute control inputs for the provided model state.
+    fn step(&self, model: &Self::Model) -> ControlInput;
+
+    /// Reset the controller to its initial state.
+    fn reset(&mut self);
+}
+
+pub(crate) fn normalize_angle(angle: f64) -> f64 {
+    let mut wrapped = angle;
+    while wrapped > std::f64::consts::PI {
+        wrapped -= 2.0 * std::f64::consts::PI;
+    }
+    while wrapped < -std::f64::consts::PI {
+        wrapped += 2.0 * std::f64::consts::PI;
+    }
+    wrapped
+}
+
+pub(crate) fn find_nearest_point_index(
+    center_line: &[(f64, f64)],
+    x: f64,
+    y: f64,
+) -> Option<usize> {
+    if center_line.is_empty() {
+        return None;
+    }
+
+    let mut nearest_index = 0usize;
+    let mut nearest_dist = f64::INFINITY;
+
+    for (index, &(cx, cy)) in center_line.iter().enumerate() {
+        let dx = cx - x;
+        let dy = cy - y;
+        let dist = dx * dx + dy * dy;
+        if dist < nearest_dist {
+            nearest_dist = dist;
+            nearest_index = index;
+        }
+    }
+
+    Some(nearest_index)
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,0 +1,3 @@
+pub mod base_controller;
+pub mod pure_pursuit;
+pub mod stanley;

--- a/src/controllers/pure_pursuit.rs
+++ b/src/controllers/pure_pursuit.rs
@@ -1,0 +1,187 @@
+use crate::controllers::base_controller::{
+    ControlInput, Controller, find_nearest_point_index, normalize_angle,
+};
+use crate::models::base_model::Model;
+use crate::models::point_mass::PointMass;
+use crate::tracks::base_track::Track;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct PurePursuitParameters {
+    pub lookahead_distance: f64,
+    pub gain: f64,
+    pub ax: f64,
+}
+
+impl PurePursuitParameters {
+    pub fn new(lookahead_distance: f64, gain: f64, ax: f64) -> Self {
+        Self {
+            lookahead_distance,
+            gain,
+            ax,
+        }
+    }
+}
+
+impl Default for PurePursuitParameters {
+    fn default() -> Self {
+        Self {
+            lookahead_distance: 5.0,
+            gain: 1.0,
+            ax: 0.0,
+        }
+    }
+}
+
+impl fmt::Display for PurePursuitParameters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "PurePursuitParameters {{ lookahead_distance: {:.3} m, gain: {:.3}, ax: {:.3} m/s² }}",
+            self.lookahead_distance, self.gain, self.ax
+        )
+    }
+}
+
+pub struct PurePursuitController<T: Track> {
+    track: Option<T>,
+    parameters: PurePursuitParameters,
+    initial_parameters: PurePursuitParameters,
+}
+
+impl<T: Track> PurePursuitController<T> {
+    pub fn new(parameters: PurePursuitParameters) -> Self {
+        Self {
+            track: None,
+            parameters: parameters.clone(),
+            initial_parameters: parameters,
+        }
+    }
+
+    pub fn track(&self) -> Option<&T> {
+        self.track.as_ref()
+    }
+
+    pub fn parameters(&self) -> &PurePursuitParameters {
+        &self.parameters
+    }
+
+    fn find_lookahead_point(&self, x: f64, y: f64) -> Option<(f64, f64)> {
+        let track = self.track.as_ref()?;
+        let center_line = track.get_center_line();
+        let nearest_index = find_nearest_point_index(center_line, x, y)?;
+
+        let n = center_line.len();
+        if n == 0 {
+            return None;
+        }
+
+        for offset in 0..n {
+            let index = (nearest_index + offset) % n;
+            let (tx, ty) = center_line[index];
+            let dx = tx - x;
+            let dy = ty - y;
+            let distance = (dx * dx + dy * dy).sqrt();
+            if distance >= self.parameters.lookahead_distance {
+                return Some((tx, ty));
+            }
+        }
+
+        Some(center_line[nearest_index])
+    }
+}
+
+impl<T: Track> Default for PurePursuitController<T> {
+    fn default() -> Self {
+        Self::new(PurePursuitParameters::default())
+    }
+}
+
+impl<T: Track> Controller for PurePursuitController<T> {
+    type Model = PointMass;
+    type Track = T;
+    type Parameters = PurePursuitParameters;
+
+    fn init(&mut self, _model: &Self::Model, track: Self::Track, parameters: Self::Parameters) {
+        self.track = Some(track);
+        self.parameters = parameters.clone();
+        self.initial_parameters = parameters;
+    }
+
+    fn step(&self, model: &Self::Model) -> ControlInput {
+        let (x, y, yaw) = model.get_position();
+        let (tx, ty) = match self.find_lookahead_point(x, y) {
+            Some(point) => point,
+            None => return ControlInput::new(0.0, 0.0),
+        };
+
+        let target_yaw = (ty - y).atan2(tx - x);
+        let heading_error = normalize_angle(target_yaw - yaw);
+        let yaw_rate = self.parameters.gain * heading_error;
+
+        ControlInput::new(self.parameters.ax, yaw_rate)
+    }
+
+    fn reset(&mut self) {
+        self.track = None;
+        self.parameters = self.initial_parameters.clone();
+    }
+}
+
+impl<T: Track> fmt::Display for PurePursuitController<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.track.as_ref() {
+            Some(track) => write!(
+                f,
+                "PurePursuitController {{ track: {}, parameters: {} }}",
+                track.get_track_name(),
+                self.parameters
+            ),
+            None => write!(
+                f,
+                "PurePursuitController {{ track: uninitialized, parameters: {} }}",
+                self.parameters
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PurePursuitController, PurePursuitParameters};
+    use crate::controllers::base_controller::Controller;
+    use crate::models::base_model::Model;
+    use crate::models::point_mass::PointMass;
+    use crate::tracks::base_track::Track;
+    use crate::tracks::circle::CircleTrack;
+
+    #[test]
+    fn test_pure_pursuit_controller_yaw_rate_positive() {
+        let track = CircleTrack::new(50.0, 10.0, 180);
+        let start = track.get_start_position();
+        let mut model = PointMass::new();
+        model.set_position(start.0, start.1, start.2);
+
+        let params = PurePursuitParameters::new(5.0, 1.0, 0.0);
+        let mut controller = PurePursuitController::new(params.clone());
+        controller.init(&model, track, params);
+
+        let control = controller.step(&model);
+        assert!(control.yaw_rate > 0.0);
+    }
+
+    #[test]
+    fn test_pure_pursuit_controller_returns_ax() {
+        let track = CircleTrack::new(50.0, 10.0, 180);
+        let start = track.get_start_position();
+        let mut model = PointMass::new();
+        model.set_position(start.0, start.1, start.2);
+
+        let params = PurePursuitParameters::new(5.0, 1.0, 1.2);
+        let mut controller = PurePursuitController::new(params.clone());
+        controller.init(&model, track, params);
+
+        let control = controller.step(&model);
+        assert!((control.ax - 1.2).abs() < 1e-9);
+    }
+}

--- a/src/controllers/stanley.rs
+++ b/src/controllers/stanley.rs
@@ -1,0 +1,181 @@
+use crate::controllers::base_controller::{
+    ControlInput, Controller, find_nearest_point_index, normalize_angle,
+};
+use crate::models::base_model::Model;
+use crate::models::point_mass::PointMass;
+use crate::tracks::base_track::Track;
+use std::fmt;
+
+#[derive(Debug, Clone)]
+pub struct StanleyParameters {
+    pub gain: f64,
+    pub softening: f64,
+    pub target_speed: f64,
+    pub ax: f64,
+}
+
+impl StanleyParameters {
+    pub fn new(gain: f64, softening: f64, target_speed: f64, ax: f64) -> Self {
+        Self {
+            gain,
+            softening,
+            target_speed,
+            ax,
+        }
+    }
+}
+
+impl Default for StanleyParameters {
+    fn default() -> Self {
+        Self {
+            gain: 1.0,
+            softening: 1.0,
+            target_speed: 5.0,
+            ax: 0.0,
+        }
+    }
+}
+
+impl fmt::Display for StanleyParameters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "StanleyParameters {{ gain: {:.3}, softening: {:.3}, target_speed: {:.3} m/s, ax: {:.3} m/s² }}",
+            self.gain, self.softening, self.target_speed, self.ax
+        )
+    }
+}
+
+pub struct StanleyController<T: Track> {
+    track: Option<T>,
+    parameters: StanleyParameters,
+    initial_parameters: StanleyParameters,
+}
+
+impl<T: Track> StanleyController<T> {
+    pub fn new(parameters: StanleyParameters) -> Self {
+        Self {
+            track: None,
+            parameters: parameters.clone(),
+            initial_parameters: parameters,
+        }
+    }
+
+    pub fn track(&self) -> Option<&T> {
+        self.track.as_ref()
+    }
+
+    pub fn parameters(&self) -> &StanleyParameters {
+        &self.parameters
+    }
+}
+
+impl<T: Track> Default for StanleyController<T> {
+    fn default() -> Self {
+        Self::new(StanleyParameters::default())
+    }
+}
+
+impl<T: Track> Controller for StanleyController<T> {
+    type Model = PointMass;
+    type Track = T;
+    type Parameters = StanleyParameters;
+
+    fn init(&mut self, _model: &Self::Model, track: Self::Track, parameters: Self::Parameters) {
+        self.track = Some(track);
+        self.parameters = parameters.clone();
+        self.initial_parameters = parameters;
+    }
+
+    fn step(&self, model: &Self::Model) -> ControlInput {
+        let track = match self.track.as_ref() {
+            Some(track) => track,
+            None => return ControlInput::new(0.0, 0.0),
+        };
+
+        let center_line = track.get_center_line();
+        let center_line_yaw = track.get_center_line_yaw();
+        let (x, y, yaw) = model.get_position();
+
+        let nearest_index = match find_nearest_point_index(center_line, x, y) {
+            Some(index) => index,
+            None => return ControlInput::new(0.0, 0.0),
+        };
+
+        let (cx, cy) = center_line[nearest_index];
+        let path_yaw = center_line_yaw.get(nearest_index).copied().unwrap_or(0.0);
+
+        let heading_error = normalize_angle(path_yaw - yaw);
+        let dx = x - cx;
+        let dy = y - cy;
+        let cross_track_error = dx * (-path_yaw.sin()) + dy * path_yaw.cos();
+        let denom = self.parameters.softening + self.parameters.target_speed.abs();
+        let correction = (self.parameters.gain * cross_track_error).atan2(denom);
+        let yaw_rate = heading_error + correction;
+
+        ControlInput::new(self.parameters.ax, yaw_rate)
+    }
+
+    fn reset(&mut self) {
+        self.track = None;
+        self.parameters = self.initial_parameters.clone();
+    }
+}
+
+impl<T: Track> fmt::Display for StanleyController<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.track.as_ref() {
+            Some(track) => write!(
+                f,
+                "StanleyController {{ track: {}, parameters: {} }}",
+                track.get_track_name(),
+                self.parameters
+            ),
+            None => write!(
+                f,
+                "StanleyController {{ track: uninitialized, parameters: {} }}",
+                self.parameters
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StanleyController, StanleyParameters};
+    use crate::controllers::base_controller::Controller;
+    use crate::models::base_model::Model;
+    use crate::models::point_mass::PointMass;
+    use crate::tracks::base_track::Track;
+    use crate::tracks::circle::CircleTrack;
+
+    #[test]
+    fn test_stanley_controller_on_center_line() {
+        let track = CircleTrack::new(50.0, 10.0, 180);
+        let start = track.get_start_position();
+        let mut model = PointMass::new();
+        model.set_position(start.0, start.1, start.2);
+
+        let params = StanleyParameters::new(1.0, 1.0, 5.0, 0.0);
+        let mut controller = StanleyController::new(params.clone());
+        controller.init(&model, track, params);
+
+        let control = controller.step(&model);
+        assert!(control.yaw_rate.abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_stanley_controller_returns_ax() {
+        let track = CircleTrack::new(50.0, 10.0, 180);
+        let start = track.get_start_position();
+        let mut model = PointMass::new();
+        model.set_position(start.0, start.1, start.2);
+
+        let params = StanleyParameters::new(2.0, 1.0, 5.0, 1.5);
+        let mut controller = StanleyController::new(params.clone());
+        controller.init(&model, track, params);
+
+        let control = controller.step(&model);
+        assert!((control.ax - 1.5).abs() < 1e-9);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
+pub mod controllers;
 pub mod models;
-pub mod tracks;
 pub mod plotting;
 pub mod simulation;
+pub mod tracks;


### PR DESCRIPTION
### Motivation
- Provide a reusable controller package with a standard lifecycle trait that accepts a model, track and typed parameters to enable closed-loop control.
- Offer common control primitives and helpers (angle normalization and nearest-path lookup) and concrete controller algorithms for trajectory following.

### Description
- Add a new `controllers` module and export it from the crate root with files `src/controllers/base_controller.rs`, `src/controllers/stanley.rs`, and `src/controllers/pure_pursuit.rs`.
- Define `ControlInput` and the `Controller` trait with `init`, `step`, and `reset`, plus helpers `normalize_angle` and `find_nearest_point_index` in `base_controller.rs`.
- Implement `StanleyController` and `PurePursuitController` with parameter types, `Display` impls, and logic in `stanley.rs` and `pure_pursuit.rs` respectively.
- Add unit tests for both controllers that validate returned `ax` and yaw-rate behaviour and wire the module into `src/lib.rs`.

### Testing
- Ran `cargo fmt` and `cargo test --verbose` in the project root.
- All repository tests passed: `cargo test --verbose` completed successfully (65 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698134f8395c832eaf6cd9309a263b36)